### PR TITLE
Update stub cases

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 18
       - name: Install dependencies
         run: npm ci
+      - name: Prisma Initiation
+        run: npm run prism:gen
       - name: Running Tests
         run: npm run pw:stub
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Prisma Initiation
-        run: npm run prism:gen
+        run: npm run prisma:gen
       - name: Running Tests
         run: npm run pw:stub
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Running Tests
-        run: npm run pw:api
+        run: npm run pw:stub
         env:
           HOME: /root
       - name: Archive

--- a/src/features/jsonPlaceholder.ts
+++ b/src/features/jsonPlaceholder.ts
@@ -5,6 +5,13 @@ export interface Post {
 	title: string;
 	body: string;
 }
+
+export interface PostBody {
+	id?: number;
+	userId: number;
+	title: string | boolean | undefined;
+	body: string | boolean | undefined;
+}
 export class JPHManager {
 	readonly baseURL: string = 'https://jsonplaceholder.typicode.com';
 	constructor() {}
@@ -24,6 +31,20 @@ export class JPHManager {
 			return (await body.json()) as Post;
 		} catch (e) {
 			throw new Error(`Unable to fetch posts, ${e}`);
+		}
+	}
+	async createNewPostWithUserId(body: PostBody): Promise<PostBody> {
+		try {
+			const post = await fetch(`${this.baseURL}/posts`, {
+				method: 'POST',
+				headers: {
+					'Content-type': 'application/json; charset=UTF-8',
+				},
+				body: JSON.stringify(body),
+			});
+			return post.json();
+		} catch (e) {
+			throw new Error(`Unabel to create new post due to > ${e}`);
 		}
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,10 @@ import { envConfig } from './configs/env';
 const host = envConfig.HOST;
 const port = envConfig.PORT;
 
-const start = async () => {
+export const start = async () => {
 	try {
 		await app.listen({ host: host, port: port as number });
-		console.log(`Server Started @ ${host}:${port}`);
+		console.log(`#### Server Started @ ${host}:${port} ####`);
 	} catch (e) {
 		app.log.error(e);
 		process.exit(1);
@@ -15,5 +15,3 @@ const start = async () => {
 };
 
 start();
-
-export { app };

--- a/src/schema/jsonPlaceHolder.ts
+++ b/src/schema/jsonPlaceHolder.ts
@@ -9,4 +9,25 @@ export namespace JPHSchema {
 			},
 		},
 	};
+	export const createNewPost = {
+		params: {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'integer',
+				},
+			},
+		},
+		body: {
+			type: 'object',
+			properties: {
+				title: {
+					type: 'string',
+				},
+				body: {
+					type: 'string',
+				},
+			},
+		},
+	};
 }

--- a/tests/integration/006-api-3rdparty-db.spec.ts
+++ b/tests/integration/006-api-3rdparty-db.spec.ts
@@ -122,4 +122,57 @@ test.describe('Local Server With 3rd Party', () => {
 			});
 		});
 	});
+
+	test.describe('#POST /post/:id', () => {
+		test('Create new post for active user should be have post data returned.', async ({
+			request,
+		}) => {
+			const res = await request.post('/api/jph/post/1', {
+				data: {
+					title: 'Active User Post title',
+					body: 'Active User Post body',
+				},
+			});
+			const body = await res.json();
+
+			await expect(res).toBeOK();
+
+			console.log(body);
+			expect(body.refId).toBeTruthy();
+			expect(body).toHaveProperty(
+				'detail',
+				'User Id of 1 has created new post with Active User Post title and Active User Post body.'
+			);
+		});
+
+		test('Create new post for inactive user should be failure', async ({
+			request,
+		}) => {
+			const res = await request.post('/api/jph/post/3', {
+				data: {
+					title: 'Active User Post title',
+					body: 'Active User Post body',
+				},
+			});
+			const body = await res.json();
+
+			expect(res.status()).toBe(404);
+			expect(body).toHaveProperty('msg', 'User Not Found');
+		});
+
+		test('Create new post for deleted user should be failure', async ({
+			request,
+		}) => {
+			const res = await request.post('/api/jph/post/4', {
+				data: {
+					title: 'Active User Post title',
+					body: 'Active User Post body',
+				},
+			});
+			const body = await res.json();
+
+			expect(res.status()).toBe(404);
+			expect(body).toHaveProperty('msg', 'User Not Found');
+		});
+	});
 });

--- a/tests/integration/007-api-3rdparty-sinon.spec.ts
+++ b/tests/integration/007-api-3rdparty-sinon.spec.ts
@@ -5,16 +5,21 @@ import { envConfig } from '~src/configs/env';
 import { app } from '~src/app';
 import * as sinon from 'sinon';
 /**
- * This stubs out the 3rd party which is jsonPlaceholder
- * This suite initiates the servier so no server running in background needed
- * Also stub the repository meaning no DB connection need either
+ * This stubs out the 3rd party which is jsonPlaceholder.
+ * In order to do so This suite has to initiate the server by itself.
+ * So no server running required.
+ * Also stub the repository meaning no DB connection need either.
+ * In conclusion, There's no need for internet connection, db or server.
  * Hopefully the realworld structure will be as easy as this one
  * Copium**
  * Pro
- * - we don't need to care about seeder data at all
- * - extremely fast
+ * - we don't need to care about anything
+ * - Extremely fast
  * Con
- * - Extremely hard because we need to find the right function
+ * - Painfully hard because we need to find the right function.
+ * - Stub with care, We want to test the logic or handler.
+ * Not the data returned (cause its a data we provided via stub).
+ * - It look very much like Unit Test, yes...
  */
 
 const getPostStub = sinon.stub(JPHManager.prototype, 'getAllPosts');
@@ -122,10 +127,6 @@ test.describe('Stub with sinon', () => {
 	});
 
 	test.describe('Creating Post various user.', () => {
-		/*
-		Control every ingest data both db and form 3rd party
-		w/o db or internet connection needed
-		 */
 		test('Create Post of active user should be successful.', async ({
 			request,
 		}) => {
@@ -182,9 +183,6 @@ test.describe('Stub with sinon', () => {
 			});
 		});
 
-		/*
-		simulating when test uncontrolable 3rd party to see our handler
-		 */
 		test('When JPH returns empty string for both title and body, Should be able to transform data.', async ({
 			request,
 		}) => {

--- a/tests/integration/007-api-3rdparty-sinon.spec.ts
+++ b/tests/integration/007-api-3rdparty-sinon.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { JPHManager } from '~src/features/jsonPlaceholder';
 import { UserManagement } from '~src/repositories/users';
 import { envConfig } from '~src/configs/env';
-import { app } from '~src/index';
+import { app } from '~src/app';
 import * as sinon from 'sinon';
 /**
  * This stubs out the 3rd party which is jsonPlaceholder
@@ -19,6 +19,12 @@ import * as sinon from 'sinon';
 
 const getPostStub = sinon.stub(JPHManager.prototype, 'getAllPosts');
 const getUserListStub = sinon.stub(UserManagement.prototype, 'getUserLists');
+const getUserByIdStub = sinon.stub(UserManagement.prototype, 'getUserById');
+const postCreatePostStub = sinon.stub(
+	JPHManager.prototype,
+	'createNewPostWithUserId'
+);
+
 const defaultPost = [
 	{
 		userId: 1,
@@ -34,7 +40,10 @@ test.describe.configure({ mode: 'default' });
 
 test.describe('Stub with sinon', () => {
 	test.beforeAll(async () => {
-		await app.ready();
+		const host = envConfig.HOST;
+		const port = envConfig.PORT;
+		await app.listen({ host: host, port: port as number });
+		// await app.ready();
 	});
 	test.afterAll(async () => {
 		await app.close();
@@ -99,7 +108,7 @@ test.describe('Stub with sinon', () => {
 		test('When user has no posts should return empty array', async ({
 			request,
 		}) => {
-			const u = [...defaultUser];
+			const u = [{ ...defaultUser[0] }];
 			u[0].id = 999;
 			getUserListStub.resolves(u as never);
 			getPostStub.resolves([]);
@@ -109,6 +118,148 @@ test.describe('Stub with sinon', () => {
 
 			await expect(res).toBeOK();
 			expect(body).toStrictEqual([]);
+		});
+	});
+
+	test.describe('Creating Post various user.', () => {
+		/*
+		Control every ingest data both db and form 3rd party
+		w/o db or internet connection needed
+		 */
+		test('Create Post of active user should be successful.', async ({
+			request,
+		}) => {
+			const u = { ...defaultUser[0] };
+			const post = {
+				title: 'Stub Post',
+				body: 'Stub Body',
+			};
+			getUserByIdStub.resolves(u as never);
+			postCreatePostStub.resolves({
+				userId: 1,
+				id: 1,
+				title: post.title,
+				body: post.body,
+			});
+
+			const res = await request.post('/api/jph/post/1', {
+				data: post,
+			});
+			const body = await res.json();
+
+			await expect(res).toBeOK();
+			expect(body.refId).toBeTruthy();
+			expect(body).toHaveProperty(
+				'detail',
+				`User Id of ${u.id} has created new post with ${post.title} and ${post.body}.`
+			);
+		});
+
+		test('Create Post of inactive user should be failure.', async ({
+			request,
+		}) => {
+			const u = { ...defaultUser[0], is_active: false };
+			const post = {
+				title: 'Stub Post',
+				body: 'Stub Body',
+			};
+			getUserByIdStub.resolves(u as never);
+			postCreatePostStub.resolves({
+				userId: 1,
+				id: 1,
+				title: post.title,
+				body: post.body,
+			});
+
+			const res = await request.post('/api/jph/post/1', {
+				data: post,
+			});
+			const body = await res.json();
+
+			expect(res.status()).toBe(404);
+			expect(body).toStrictEqual({
+				msg: 'User Not Found',
+			});
+		});
+
+		/*
+		simulating when test uncontrolable 3rd party to see our handler
+		 */
+		test('When JPH returns empty string for both title and body, Should be able to transform data.', async ({
+			request,
+		}) => {
+			const u = { ...defaultUser[0] };
+			const post = {
+				title: '',
+				body: '',
+			};
+			getUserByIdStub.resolves(u as never);
+			postCreatePostStub.resolves({
+				userId: 1,
+				id: 1,
+				title: post.title,
+				body: post.body,
+			});
+
+			const res = await request.post('/api/jph/post/1', {
+				data: post,
+			});
+			const body = await res.json();
+
+			await expect(res).toBeOK();
+			expect(body).toHaveProperty(
+				'detail',
+				`User Id of ${u.id} has created new post with ${post.title} and ${post.body}.`
+			);
+		});
+
+		test('When JPH returns boolean instead of string, should be able to handle as normal string.', async ({
+			request,
+		}) => {
+			const u = { ...defaultUser[0] };
+			const post = {
+				title: true,
+				body: false,
+			};
+			getUserByIdStub.resolves(u as never);
+			postCreatePostStub.resolves({
+				userId: 1,
+				id: 1,
+				title: post.title,
+				body: post.body,
+			});
+
+			const res = await request.post('/api/jph/post/1', {
+				data: post,
+			});
+			const body = await res.json();
+
+			await expect(res).toBeOK();
+			expect(body).toHaveProperty(
+				'detail',
+				`User Id of ${u.id} has created new post with ${post.title} and ${post.body}.`
+			);
+		});
+		test('When JPH returns undefined properties.', async ({ request }) => {
+			const u = { ...defaultUser[0] };
+			getUserByIdStub.resolves(u as never);
+			postCreatePostStub.resolves({
+				userId: 1,
+				id: 1,
+				title: undefined,
+				body: undefined,
+			});
+
+			const res = await request.post('/api/jph/post/1', {
+				data: {},
+			});
+			const body = await res.json();
+
+			await expect(res).toBeOK();
+			expect(body).toHaveProperty(
+				'detail',
+				`User Id of ${u.id} has created new post with undefined and undefined.`
+			);
 		});
 	});
 });


### PR DESCRIPTION
* Add more simple API with simple random data transformation (`#POST`/posts)
* Add API request poc for JPH's create post (in `006`)
* Add stub cases for Creating JPH's post (in `007`)
* Update the github action to run project of `pw:stub` instead. this is a POC of testing API with neither Server or DB is running